### PR TITLE
Simple fix for non-RGB images, just in case

### DIFF
--- a/CreatePlanet.py
+++ b/CreatePlanet.py
@@ -44,6 +44,10 @@ def createplanet(image, atmospherecolor, postprocessing, planetrand, planetwidth
 	if groupundo:
 		image.undo_group_start()
 
+# check if image is in RGB, if not then change type
+        if image.base_type != RGB:
+                pdb.gimp_convert_rgb(image)
+
 # rescale the image to square
 	if image.width < image.height:
 		pdb.gimp_image_rotate(image, 0)


### PR DESCRIPTION
When mass-producing sprites, I hit an error because the script couldn't add a black background to non-RGB images, and I figured this was the simplest solution, rather than adding support for non-rgb images.