### PR TITLE
Added path expansion & made default path cross-platform

### DIFF
--- a/CreatePlanet.py
+++ b/CreatePlanet.py
@@ -1,6 +1,8 @@
 #!/usr/bin/env python
 
 import os
+from os.path import expanduser
+from sys import platform
 import random
 from math import radians
 
@@ -10,8 +12,13 @@ from gimpfu import *
 Insert your default file path here. If you are on windows, remember to escape the backslashes with another backslash.
 Example: C:\\Users\\Name\\test.png
 """
-DEFAULT_PATH = "C:\\Users\\Florian\\test.png"
+DEFAULT_PATH_WINDOWS = "C:\\Users\\Florian\\test.png"
+DEFAULT_PATH_LINUXMAC = "~/test.png"
 
+if platform == "win32":
+	DEFAULT_PATH = DEFAULT_PATH_WINDOWS
+else:
+	DEFAULT_PATH = expanduser(DEFAULT_PATH_LINUXMAC)
 
 pdb = gimp.pdb
 

--- a/CreatePlanet.py
+++ b/CreatePlanet.py
@@ -2,6 +2,7 @@
 
 import os
 from os.path import expanduser
+from os.path import isabs
 from sys import platform
 import random
 from math import radians
@@ -10,12 +11,14 @@ from gimpfu import *
 
 """
 Insert your default file path here. If you are on windows, remember to escape the backslashes with another backslash.
-This is relative to your home directory
+This is relative to your home directory. You can also pass an absolute path if you so choose
 Example: Desktop\\test.png
 """
 DEFAULT_PATH = "planet.png"
 
-if platform == "win32":
+if(isabs(DEFAULT_PATH)):
+	pass
+elif platform == "win32":
 	DEFAULT_PATH = expanduser("~\\" + DEFAULT_PATH)
 else:
 	DEFAULT_PATH = expanduser("~/" + DEFAULT_PATH)

--- a/CreatePlanet.py
+++ b/CreatePlanet.py
@@ -10,15 +10,15 @@ from gimpfu import *
 
 """
 Insert your default file path here. If you are on windows, remember to escape the backslashes with another backslash.
-Example: C:\\Users\\Name\\test.png
+This is relative to your home directory
+Example: Desktop\\test.png
 """
-DEFAULT_PATH_WINDOWS = "C:\\Users\\Florian\\test.png"
-DEFAULT_PATH_LINUXMAC = "~/test.png"
+DEFAULT_PATH = "planet.png"
 
 if platform == "win32":
-	DEFAULT_PATH = DEFAULT_PATH_WINDOWS
+	DEFAULT_PATH = expanduser("~\\" + DEFAULT_PATH)
 else:
-	DEFAULT_PATH = expanduser(DEFAULT_PATH_LINUXMAC)
+	DEFAULT_PATH = expanduser("~/" + DEFAULT_PATH)
 
 pdb = gimp.pdb
 


### PR DESCRIPTION
Alright so this code *should* be cross platform, but that said I haven't tested on Mac or Windows. It's pretty much guaranteed to run on Mac since Mac uses a normal path system, but I'd check on Windows before merging. I would myself but I don't own a Windows machine.

Anyways, pretty much what this does is make `DEFAULT_PATH` relative to the user's home directory so that the default value of `DEFAULT_PATH` works on all platforms, not just Windows. Note that it actually expands, so in GIMP it will show the full path (for example, `/home/alden/planet.png`) not the shortened path (`~/planet.png`).

This *has* been tested on Linux, and the path expansion has been tested on Windows (I know that `~` isn't supposed to be possible on Windows but Python is smart and lets you do it anyways. That particular function *has* been tested by some random guy on Discord so I'm not just saying that).